### PR TITLE
Let span.add_tool_call() report a failed tool call

### DIFF
--- a/TRACING.md
+++ b/TRACING.md
@@ -108,7 +108,7 @@ with tracer.trace("agent-name", framework="langchain") as span:
 |---|---|
 | `span.input = value` | Override the captured input |
 | `span.output = value` | Set the output (required in context manager mode) |
-| `span.add_tool_call(name, *, input, output, latency_ms)` | Record a tool call made during the span |
+| `span.add_tool_call(name, *, input, output, success, error, latency_ms)` | Record a tool call made during the span; `success=False` marks it failed |
 | `span.set_error(message)` | Mark the span as failed with the given error message |
 
 ---
@@ -236,9 +236,22 @@ with tracer.trace("rag-agent", framework="langchain") as span:
 
 Tool calls are displayed in the expanded trace view in the AgentX UI with per-call latency.
 
+Pass `success=False` (plus an optional `error`) for a call that failed - that's what Monitor's
+built-in "Tool failure" check and the dashboard's Tool quality column read:
+
+```python
+    span.add_tool_call(
+        "lookup_order", input=order_id, output="error: upstream timeout",
+        success=False, error="upstream timeout", latency_ms=3000,
+    )
+```
+
+Leaving `success` unset means "unknown", not "passed" - the dashboard falls back to its
+output-text heuristic for those.
+
 ### Capturing tool failures: `tracer.trace_tool_call()`
 
-`add_tool_call()` reports a call after the fact; `tracer.trace_tool_call()` wraps the execution itself, timing it and capturing failures automatically:
+`add_tool_call()` reports a call after the fact, with the outcome you pass it; `tracer.trace_tool_call()` wraps the execution itself, timing it and capturing failures automatically:
 
 ```python
 with tracer.trace("support-agent") as span:
@@ -250,7 +263,7 @@ with tracer.trace("support-agent") as span:
     span.output = answer
 ```
 
-An exception escaping the block records the call with `success=False` plus the error text, then propagates unchanged so your own error handling still runs. That `success: false` is what Monitor's built-in "Tool failure" check and the dashboard's Tool quality column read, so a flaky tool shows up in triage without any extra wiring. To set the outcome yourself instead (an API that returned a well-formed error payload, say), use `tracer.record_tool_call(name, input=..., output=..., success=False, error="...")`.
+An exception escaping the block records the call with `success=False` plus the error text, then propagates unchanged so your own error handling still runs. That `success: false` is what Monitor's built-in "Tool failure" check and the dashboard's Tool quality column read, so a flaky tool shows up in triage without any extra wiring. To set the outcome yourself instead (an API that returned a well-formed error payload, say), use `tracer.record_tool_call(name, input=..., output=..., success=False, error="...")`, or `span.add_tool_call(...)` with the same `success`/`error` arguments when you already have a span in hand.
 
 ---
 

--- a/agentx/tracing/tracer.py
+++ b/agentx/tracing/tracer.py
@@ -444,15 +444,30 @@ class _TraceSpan:
         *,
         input: Any = None,
         output: Any = None,
+        success: Optional[bool] = None,
+        error: Optional[str] = None,
         latency_ms: Optional[int] = None,
     ) -> None:
-        """Record a tool call made during this span."""
-        self.tool_calls.append({
+        """
+        Record a tool call made during this span.
+
+        ``success``/``error`` mark a failed call, same semantics as
+        :meth:`Tracer.record_tool_call`. ``success=False`` is what the engine's built-in "Tool
+        failure" Monitor check and the dashboard's Tool quality column both read; leaving
+        ``success`` unset means "unknown" (the key is omitted entirely) and the dashboard falls
+        back to its output-text heuristic instead of assuming the call passed.
+        """
+        entry: Dict[str, Any] = {
             "name": name,
             "input": _safe_serialize(input) if input is not None else None,
             "output": _safe_serialize(output) if output is not None else None,
             "latency_ms": latency_ms,
-        })
+        }
+        if success is not None:
+            entry["success"] = success
+        if error is not None:
+            entry["error"] = error
+        self.tool_calls.append(entry)
 
     def set_error(self, message: str) -> None:
         """Mark this span as failed with the given error message."""

--- a/tests/test_span_tree.py
+++ b/tests/test_span_tree.py
@@ -623,3 +623,37 @@ def test_record_tool_call_with_no_active_span_still_queues():
     wires = enqueued_wires(tracer)
     assert len(wires) == 1
     assert wires[0]["tool_calls"][0]["name"] == "orphan_call"
+
+
+def test_add_tool_call_carries_failure_onto_the_wire():
+    """span.add_tool_call() is the in-`with`-block way to report a call after the fact, so it has
+    to be able to say the call failed — `success: false` on the root's flat tool_calls list is
+    exactly what the engine's built-in "Tool failure" check and the dashboard's Tool quality
+    column read (trajectory.ts's `tc.success !== false`, ingest.ts's chainOfActions)."""
+    tracer = make_tracer()
+    with tracer.trace("agent") as span:
+        span.add_tool_call(
+            "lookup_thing", input="x", output="error: timeout",
+            success=False, error="timeout", latency_ms=50,
+        )
+
+    wires = enqueued_wires(tracer)
+    assert len(wires) == 1
+    tc = wires[0]["tool_calls"][0]
+    assert tc["name"] == "lookup_thing"
+    assert tc["success"] is False
+    assert tc["error"] == "timeout"
+    assert tc["latency_ms"] == 50
+
+
+def test_add_tool_call_without_success_omits_the_field():
+    """Unset means "unknown", not "passed" — same as record_tool_call. Emitting success=True (or
+    a null) here would tell the dashboard's Tool quality column the call definitively passed and
+    suppress its output-text heuristic, so the key stays off the dict entirely."""
+    tracer = make_tracer()
+    with tracer.trace("agent") as span:
+        span.add_tool_call("lookup_thing", input="x", output="y", latency_ms=5)
+
+    tc = enqueued_wires(tracer)[0]["tool_calls"][0]
+    assert "success" not in tc
+    assert "error" not in tc


### PR DESCRIPTION
`_TraceSpan.add_tool_call()` accepted only `name`/`input`/`output`/`latency_ms`, so it had no way to express a failed call — even though it is the tool-call API that reads most naturally inside `with client.tracer.trace(...) as span:`.

That gap matters because `tool_calls[].success === false` on the root trace's flat list is exactly what both backends read for tool-failure detection:

- **self-host engine** — the built-in "Tool failure" check (`engine/src/core/monitor/detect.ts`, `call.success === false`) and `engine/src/core/trace/trajectory.ts` (`const ok = tc.success !== false`)
- **hosted API** — `src/routes/api_v1/ingest.ts` builds `chainOfActions` from `tc.success`

`Tracer.record_tool_call()` and `Tracer.trace_tool_call()` already take and document `success`/`error`; only the span-level method was left behind, so callers worked around it by assigning `span.tool_calls` directly (AgentX-trace-eval's `scripts/smoke_test.py` did exactly that).

## Change

`success: Optional[bool] = None` and `error: Optional[str] = None`, mirroring `record_tool_call()`'s semantics precisely — **both keys are omitted from the appended dict when unset**, so absent still means "unknown", not "passed", and the dashboard keeps falling back to its output-text heuristic.

```python
with client.tracer.trace("support-agent") as span:
    span.add_tool_call(
        "lookup_order", input=order_id, output="error: upstream timeout",
        success=False, error="upstream timeout", latency_ms=3000,
    )
```

`TRACING.md` is updated to match (signature table, a failed-call example, and the `trace_tool_call()` section's "set the outcome yourself" note).

## Verification

Ran the real SDK against a mocked ingest client — the root wire payload carries `{'name': 'lookup_thing', 'input': 'x', 'output': 'error: timeout', 'latency_ms': 50, 'success': False, 'error': 'timeout'}`, which satisfies `detect.ts`'s `call.success === false` and makes `trajectory.ts`'s `ok` false. On the hosted path, `ingest.ts`'s `typeof tc.success === "boolean" ? tc.success : undefined` passes `false` through to `chainOfActions` (it projects only name/input/output/latencyMs/success, so `error` is dropped there — same as `record_tool_call()` already behaves). The engine's ingest schema is `z.array(z.record(z.unknown()))`, so the added `error` key is not a validation risk.

Two new tests in `tests/test_span_tree.py`: failure reaches the wire, and an unset `success` omits both keys. `tests/test_span_tree.py` goes 19 → 21 passing; the 3 pre-existing failures (2 Google ADK import errors, 1 `trace_tool_call` dual-write assertion) are unchanged and untouched by this PR.

## Follow-up

The companion cleanup, https://github.com/AgentX-ai/AgentX-Trace-Eval/pull/10, drops that `span.tool_calls` workaround. Its smoke test installs `agentx-python` from PyPI, so it needs a release cut from this branch before it can merge — 0.6.28 (latest published) does not have these kwargs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
