### PR TITLE
Stop paying for a missing-results round trip on every run

### DIFF
--- a/agentx/evaluations/client.py
+++ b/agentx/evaluations/client.py
@@ -404,10 +404,6 @@ class EvaluationsClient:
 
         return self._report_from_dashboard(run_id)
 
-    def get_missing_results(self, run_id: str) -> List[Dict[str, Any]]:
-        data = self._request("GET", f"/runs/{run_id}/missing-results")
-        return data if isinstance(data, list) else data.get("missing", [])
-
     # ------------------------------------------------------------------
     # Self-host analysis fallback
     #

--- a/agentx/evaluations/runner.py
+++ b/agentx/evaluations/runner.py
@@ -201,13 +201,21 @@ class EvaluationRunContext:
                 logger.error("Failed to submit batch %s: %s", batch_id[:8], exc)
 
     def _fetch_submitted_keys(self) -> Set[str]:
-        try:
-            missing = self._client.get_missing_results(self._run.run_id)
-            # missing-results returns cases NOT yet submitted - we want the inverse
-            # but if the endpoint isn't live yet, just return empty set
-            return set()
-        except Exception:
-            return set()
+        """Idempotency keys ``execute()`` should skip. Always empty today.
+
+        This is the seam a cross-process resume would fill: ask the server which cases
+        of ``run_id`` already have results, and skip re-running them. It stays empty
+        because there is no way to reach an already-populated run - ``evaluations.run()``
+        POSTs a fresh run id every time and is the only way to build this context, so a
+        run arriving at ``execute()`` has no results yet by construction. Resume would
+        first need a re-attach entry point - an ``evaluations.resume(run_id)`` that does
+        not exist yet - before an answer here could ever be non-empty.
+
+        It used to ask GET /runs/{runId}/missing-results, throw the reply away, and
+        return this same empty set: a round trip per run that changed nothing, and a
+        guaranteed 404 on the self-host engine, which does not implement that route.
+        """
+        return set()
 
     # ------------------------------------------------------------------
     # Step 2: finalize


### PR DESCRIPTION
`EvaluationRunContext._fetch_submitted_keys()` asked `GET /runs/:runId/missing-results`, assigned the reply to a local nobody read, and returned an empty set either way. `execute()` calls it once per run, so every evaluation paid for a request that could not change what it did next.

## Why not finish the resume instead

The comment there describes a resume: turn the "not yet submitted" list into the set of cases already done, and skip them. That can't work as the SDK is shaped today.

`evaluations.run()` POSTs a fresh run id, and it is the only way to build the context that reaches `execute()`. A run getting there has no results yet by construction — the server would name *every* case as missing, and the inverse would be empty on every call. Finishing the arithmetic would have kept the round trip and still skipped nothing.

The hosted endpoint itself is fine, for the record: it's API-key authable and its key format (`${runId}:${caseId}:run-${runNumber}`) matches the SDK's `_idem_key()` exactly. Resume needs a re-attach entry point first — an `evaluations.resume(run_id)` that doesn't exist.

## What this does

The request goes; the seam stays. `_fetch_submitted_keys()` returns an empty set without touching the network and records in its docstring what would have to change for it to return anything else. `execute()` keeps its skip branch, ready for the day a run can arrive already populated.

It also closes this for self-host, which never implemented the route — those runs were spending a request per evaluation on a guaranteed 404.

`get_missing_results()` goes too, having lost its only caller. Keeping it would keep an endpoint on the SDK's surface that nothing reaches, which is exactly what the endpoint contract exists to prevent.

## Merges as a set

| | |
|---|---|
| this PR | the SDK stops calling the endpoint |
| #17 | drops the contract test's driver for it |
| AgentX-ai/AgentX-Trace-Eval#9 | drops its row from `contracts/sdk-endpoints.json` |

Until all three land, `test_endpoint_contract.py` and the SDK disagree about whether `missing-results` is called. In practice that suite skips when the contract file isn't reachable, so nothing goes red in between — but they should land together.

## Verification

`tests/test_endpoint_contract.py` passes 4/4 against the updated contract, and `test_selfhost_analysis_fallback.py` passes alongside it (15 total). Run against the pre-edit 57-row contract it fails with exactly the two assertions that should catch this:

```
contract rows with no driver in this test
contracts/sdk-endpoints.json lists endpoints this SDK no longer calls:
  ['GET /custom-agent-evaluations/runs/*/missing-results']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)