### PR TITLE
client.export (bulk NDJSON backup) + client.monitor.calibration

### DIFF
--- a/agentx/agentx.py
+++ b/agentx/agentx.py
@@ -70,6 +70,12 @@ class AgentX:
         # The read side of tracing: trace-by-id detail and paginated listing (P1.2).
         self.traces = TracesClient(api_key=self.api_key)
 
+        from agentx.export import ExportClient
+
+        # Bulk NDJSON egress for backup/migration (P2.1): manifest, per-entity streaming, and
+        # directory dumps. Self-host only.
+        self.export = ExportClient(api_key=self.api_key)
+
         from agentx.feedback import FeedbackClient
 
         # Forward end-user votes ("up"/"down") on traced responses - a "down" raises a signal

--- a/agentx/export.py
+++ b/agentx/export.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Iterator, List, Optional
+
+import requests
+
+from agentx.util import api_base, get_headers
+
+logger = logging.getLogger(__name__)
+
+
+class AgentXExportError(Exception):
+    pass
+
+
+class ExportClient:
+    """Surfaced as ``client.export``: bulk NDJSON egress for backup and migration (self-host).
+
+    The engine's ``GET /export`` manifest lists every exportable entity (traces, signals,
+    events, runs, feedback, outcomes, scorer config, ...) with live row counts;
+    ``GET /export/<entity>`` streams the rows as NDJSON. Everything is scoped to the API key's
+    project, so an export can never cross a tenant boundary.
+
+    Typical uses::
+
+        client.export.dump("./backup")                     # full backup, one .ndjson per entity
+        client.export.dump("./nightly", since=yesterday)   # incremental
+        for row in client.export.iter("traces"):           # stream without touching disk
+            ...
+
+    Restore paths are documented in the self-host backup runbook: replay traces through
+    ``client.tracer`` / ``POST /ingest/traces``, or restore at the database level
+    (``pg_dump`` / SQLite file copy). There is deliberately no blind row-import endpoint.
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        self._api_key = api_key
+
+    def manifest(self) -> List[Dict[str, Any]]:
+        """The exportable entities with live row counts: ``[{entity, rows, path}, ...]``."""
+        resp = requests.get(
+            f"{api_base()}/export", headers=get_headers(self._api_key), timeout=30
+        )
+        if resp.status_code >= 400:
+            raise AgentXExportError(f"Export manifest failed ({resp.status_code}): {resp.text[:200]}")
+        return resp.json().get("entities", [])
+
+    def iter(self, entity: str, since: Optional[str] = None) -> Iterator[Dict[str, Any]]:
+        """Stream one entity's rows as dicts without buffering the whole table in memory.
+        ``since`` is an ISO-8601 date for incremental pulls (filters on the entity's own
+        timestamp column, e.g. ``createdAt`` for traces, ``lastSeenAt`` for signals)."""
+        params = {"since": since} if since else None
+        resp = requests.get(
+            f"{api_base()}/export/{entity}",
+            headers=get_headers(self._api_key),
+            params=params,
+            stream=True,
+            timeout=120,
+        )
+        if resp.status_code >= 400:
+            raise AgentXExportError(f"Export of {entity!r} failed ({resp.status_code}): {resp.text[:200]}")
+        for line in resp.iter_lines(decode_unicode=True):
+            if line and line.strip():
+                yield json.loads(line)
+
+    def dump(
+        self,
+        directory: str,
+        entities: Optional[List[str]] = None,
+        since: Optional[str] = None,
+    ) -> Dict[str, int]:
+        """Write ``<entity>.ndjson`` files (plus a ``manifest.json``) into ``directory`` and
+        return ``{entity: rows_written}``. Defaults to every entity the engine advertises;
+        pass ``entities`` to restrict, ``since`` for an incremental snapshot."""
+        os.makedirs(directory, exist_ok=True)
+        manifest = self.manifest()
+        wanted = [e["entity"] for e in manifest] if entities is None else entities
+        written: Dict[str, int] = {}
+        for entity in wanted:
+            path = os.path.join(directory, f"{entity}.ndjson")
+            count = 0
+            with open(path, "w", encoding="utf-8") as fh:
+                for row in self.iter(entity, since=since):
+                    fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    count += 1
+            written[entity] = count
+            logger.debug("Exported %d %s rows to %s", count, entity, path)
+        with open(os.path.join(directory, "manifest.json"), "w", encoding="utf-8") as fh:
+            json.dump(
+                {"entities": manifest, "written": written, **({"since": since} if since else {})},
+                fh,
+                indent=2,
+            )
+        return written

--- a/agentx/monitor/client.py
+++ b/agentx/monitor/client.py
@@ -213,6 +213,17 @@ class MonitorClient:
         plus deltas vs the prior window and the run-outcome breakdown."""
         return self._request("GET", "/kpis", params={"window": window})
 
+    def calibration(self, window: str = "7d") -> dict:
+        """Project-level judge calibration over a window ("24h", "7d", or "30d"): how often
+        AgentX's own verdicts agreed with real-world ground truth reported later (ops outcomes
+        via ``client.outcomes`` and end-user downvotes). Returns the dashboard's Judge
+        Calibration numbers: compared count, agreement, falsePositiveRate, falseNegativeRate.
+        Per-evaluator calibration lives on ``client.monitor.online_evaluators.calibration``."""
+        return self._request(
+            "GET", "/agent-monitoring/calibration",
+            base=self._api_root(), params={"window": window},
+        )
+
     # ------------------------------------------------------------------
     # Signal endpoints
     # ------------------------------------------------------------------


### PR DESCRIPTION
- ExportClient: manifest() with live row counts, iter(entity, since=) streaming, dump(dir, entities=, since=) writing <entity>.ndjson + manifest.json
- monitor.calibration(window): project-level judge-calibration roll-up (comparedCount/agreement/FP/FN) - closes the last REST-only read in UC4